### PR TITLE
Updates Finnish identifier validator due to government reform

### DIFF
--- a/Collector.Common.Validation.Test/NationalIdentifier/FinnishValidatorTests.cs
+++ b/Collector.Common.Validation.Test/NationalIdentifier/FinnishValidatorTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using Collector.Common.Validation.NationalIdentifier.Validators;
 using NUnit.Framework;
@@ -66,6 +66,26 @@ namespace Collector.Common.Validation.Test.NationalIdentifier
                     yield return "181285-8056";
                     yield return "290232-2001"; // 1932 has leapyear
                     yield return "290204A500F"; // 2004 has leapyear
+                    yield return "010594Y9021";
+                    yield return "020594X903P";
+                    yield return "020594X902N";
+                    yield return "030594W903B";
+                    yield return "030694W9024";
+                    yield return "040594V9030";
+                    yield return "040594V902Y";
+                    yield return "050594U903M";
+                    yield return "050594U902L";
+                    yield return "010516B903X";
+                    yield return "010516B902W";
+                    yield return "020516C903K";
+                    yield return "020516C902J";
+                    yield return "030516D9037";
+                    yield return "030516D9026";
+                    yield return "010501E9032";
+                    yield return "020502E902X";
+                    yield return "020503F9037";
+                    yield return "020504A902E";
+                    yield return "020504B904H";
                 }
             }
 

--- a/Nationaldentifier/Validators/FinnishNationalIdentifierValidator.cs
+++ b/Nationaldentifier/Validators/FinnishNationalIdentifierValidator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
@@ -12,14 +12,14 @@ namespace Collector.Common.Validation.NationalIdentifier.Validators
     ///        is calculated by taking the remainder of the value DDMMYYZZZ divide by 31.
     /// Century of the birthdate is determined by the Century sign
     ///     + = 1800
-    ///     - = 1900
-    ///     A = 2000
+    ///     -, Y, X, W, V or U = 1900
+    ///     A, B, C, D, E or F = 2000
     /// </remarks>
     public class FinnishNationalIdentifierValidator : NationalIdentifierValidator
     {
         /// <remarks>Regex has been check with SDL Regex Fuzzer tool so it should not be a source for DOS attacks. IF YOU UPDATE THE REGEX recheck it again with the SDL tool.</remarks>>
         private static readonly Regex NationalIdentifierWhitelistValidator =
-            new Regex(@"^[0-3]\d[0-1]\d{3}[\-+A]\d{3}[0123456789ABCDEFHJKLMNPRSTUVWXY]$", RegexOptions.ECMAScript);
+            new Regex(@"^[0-3]\d[0-1]\d{3}[\-+ABCDEFYXWVU]\d{3}[0123456789ABCDEFHJKLMNPRSTUVWXY]$", RegexOptions.ECMAScript);
 
         private static readonly char[] ControlChar = "0123456789ABCDEFHJKLMNPRSTUVWXY".ToCharArray();
 
@@ -27,7 +27,17 @@ namespace Collector.Common.Validation.NationalIdentifier.Validators
         {
             {'+', 1800},
             {'-', 1900},
-            {'A', 2000}
+            {'Y', 1900},
+            {'X', 1900},
+            {'W', 1900},
+            {'V', 1900},
+            {'U', 1900},
+            {'A', 2000},
+            {'B', 2000},
+            {'C', 2000},
+            {'D', 2000},
+            {'E', 2000},
+            {'F', 2000}
         };
 
         public override CountryCode CountryCode => CountryCode.FI;


### PR DESCRIPTION
Due to coming reform of personal identity code in Finland, additional century characters must be added 

More information about reform: https://dvv.fi/en/reform-of-personal-identity-code

Test cases are taken from excel file which is provided in website.