### PR TITLE
Prevent IsDateValid from throwing when year is 0

### DIFF
--- a/Collector.Common.Validation.Test/NationalIdentifier/SwedishValidatorTests.cs
+++ b/Collector.Common.Validation.Test/NationalIdentifier/SwedishValidatorTests.cs
@@ -100,6 +100,7 @@ namespace Collector.Common.Validation.Test.NationalIdentifier
                     yield return "330229-7316"; // 1933 does not have leapyear
                     yield return "050229-5009"; // 2005 does not have leapyear
                     yield return "581023-9574"; // Control number not correct
+                    yield return "000000000000"; // Valid format. Invalid year, month, day etc.
                 }
             }
 

--- a/Nationaldentifier/Validators/NationalIdentifierValidator.cs
+++ b/Nationaldentifier/Validators/NationalIdentifierValidator.cs
@@ -57,6 +57,11 @@ namespace Collector.Common.Validation.NationalIdentifier.Validators
 
         internal static bool IsValidDate(int year, int month, int day)
         {
+            if (year <= 0 || year > 9999)
+            {
+                return false;
+            }
+
             var maxDaysInMonth = new[] {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
             if (DateTime.IsLeapYear(year))
                 maxDaysInMonth[1] = 29;


### PR DESCRIPTION
IsDateValid calls IsLeapYear which throws an exception if the year is <= 0 or > 9999. IsDateValid should never throw an exception.